### PR TITLE
fix: try global `crypto` if no `window` is defined in ESM module

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,5 +1,14 @@
 // Strict ESM env, designed to run outside Node.js in envs that provide WebCrypto (deno, browsers, etc)
 
 export default function getRandomValues(typedArray) {
-  return window.crypto.getRandomValues(typedArray)
+  const crypto =
+    typeof window !== 'undefined' && 'crypto' in window
+      ? window.crypto
+      : globalThis.crypto
+
+  if (!crypto || !crypto.getRandomValues) {
+    throw new Error('WebCrypto not available in this environment')
+  }
+
+  return getRandomValues(typedArray)
 }


### PR DESCRIPTION
[Getting reports](https://sanity-io-land.slack.com/archives/C9Z7RC3V1/p1707426669510809) of the `@sanity/block-tools` package not working in certain environments, when it tries to generate keys using this module.

The reason being that we're trying to access `window.crypto` in environments where `window` is not defined (such as in Node ESM, workers etc)