### PR TITLE
[Fix] recursive call

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -10,5 +10,5 @@ export default function getRandomValues(typedArray) {
     throw new Error('WebCrypto not available in this environment')
   }
 
-  return getRandomValues(typedArray)
+  return crypto.getRandomValues(typedArray)
 }


### PR DESCRIPTION
After a check to ensure crypto.getRandomValues exists, the function goes on to call itself instead of crypto.getRandomValues, causing a recursive issue overloading the call stack